### PR TITLE
`bundle_strength` and `mode` arguments in `edge_bundle_path`

### DIFF
--- a/R/bundle_path.R
+++ b/R/bundle_path.R
@@ -53,7 +53,7 @@ edge_bundle_path <- function(g, xy, max_distortion = 2, weight_fac = 2, segments
         }
         skip[e] <- TRUE
         g1 <- igraph::delete.edges(g, which(skip))
-        sp_verts <- suppressWarnings(igraph::shortest_paths(g1, s, t, weights = weights[!skip], mode=mode)$vpath[[1]])
+        sp_verts <- suppressWarnings(igraph::shortest_paths(g1, s, t, weights = weights[!skip], mode = mode)$vpath[[1]])
         if (length(sp_verts) < 2) {
             skip[e] <- FALSE
             next
@@ -90,13 +90,13 @@ path_length <- function(verts, xy) {
 }
 
 subdivide <- function(points, bs) {
-    for (i in seq_len(bs-1)) {
+    for (i in seq_len(bs - 1)) {
         pnrow <- nrow(points)
-        newCP <- points[1,]
-        for (j in 1:(pnrow-1)) {
+        newCP <- points[1, ]
+        for (j in 1:(pnrow - 1)) {
             p1 <- points[j,]
-            p2 <- points[j+1,]
-            p3 <- (p1+p2)/2
+            p2 <- points[j + 1,]
+            p3 <- (p1 + p2) / 2
             newCP <- rbind(newCP, p3)
             newCP <- rbind(newCP, p2)
         }

--- a/man/edge_bundle_path.Rd
+++ b/man/edge_bundle_path.Rd
@@ -4,7 +4,15 @@
 \alias{edge_bundle_path}
 \title{Edge-Path Bundling}
 \usage{
-edge_bundle_path(g, xy, max_distortion = 2, weight_fac = 2, segments = 20)
+edge_bundle_path(
+  g,
+  xy,
+  max_distortion = 2,
+  weight_fac = 2,
+  segments = 20,
+  bundle_strength = 1,
+  mode = "out"
+)
 }
 \arguments{
 \item{g}{an igraph object}
@@ -16,6 +24,10 @@ edge_bundle_path(g, xy, max_distortion = 2, weight_fac = 2, segments = 20)
 \item{weight_fac}{edge weight factor}
 
 \item{segments}{number of subdivisions of edges}
+
+\item{bundle_strength}{bundle strength factor}
+
+\item{mode}{the parameter fo shortest_paths}
 }
 \value{
 data.frame containing the bundled edges


### PR DESCRIPTION
Thank you very much for developing this useful library. 
I have made following changes to the `edge_bundle_path` function and thought if it could be merged for the general use.

- `bundle_strength` argument
Implemenation of the original JS function (`subdivide`) that controls the strength of bundling.

- `mode` argument
The argument to be passed to `igraph::shortest_paths` function. Currently the `mode` parameter will be fixed to `out` and I thought it would be useful to pass this parameter arbitrarily, such as `all`.

I would be grateful if you could review this pull request.